### PR TITLE
[Home] 컨테이너 위젯 틀 완성

### DIFF
--- a/lib/ui/pages/home/home_page.dart
+++ b/lib/ui/pages/home/home_page.dart
@@ -9,8 +9,9 @@ class HomePage extends StatelessWidget {
         FocusScope.of(context).unfocus();
       },
       child: Scaffold(
-        backgroundColor: Colors.purple[50],
+        backgroundColor: const Color.fromARGB(255, 247, 238, 249),
         appBar: AppBar(
+          backgroundColor: const Color.fromARGB(255, 247, 238, 249),
           title: TextField(
             maxLines: 1,
             controller: textEditingController,
@@ -52,9 +53,16 @@ class HomePage extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
-                          Text('코엑스'), //title
+                          Text(
+                            '코엑스아쿠아리움',
+                            style: TextStyle(
+                              fontSize: 20,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ), //title
+
                           Text('문화,예술>컨벤션센터'), //category
-                          Text('서울특별시 강남구 영동대로 513'), //address
+                          Text('서울특별시 강남구 영동대로 513'), //roadAddress
                         ],
                       ),
                     ),

--- a/lib/ui/pages/home/home_page.dart
+++ b/lib/ui/pages/home/home_page.dart
@@ -47,6 +47,7 @@ class HomePage extends StatelessWidget {
                         borderRadius: BorderRadius.circular(20),
                         color: Colors.white,
                       ),
+                      padding: EdgeInsets.all(20),
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/ui/pages/home/home_page.dart
+++ b/lib/ui/pages/home/home_page.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class HomePage extends StatelessWidget {
   TextEditingController textEditingController = TextEditingController();
-
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
@@ -11,6 +9,7 @@ class HomePage extends StatelessWidget {
         FocusScope.of(context).unfocus();
       },
       child: Scaffold(
+        backgroundColor: Colors.purple[50],
         appBar: AppBar(
           title: TextField(
             maxLines: 1,
@@ -34,7 +33,36 @@ class HomePage extends StatelessWidget {
             ),
           ),
         ),
-        body: Text('HomePage'),
+        body: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            children: [
+              Expanded(
+                child: ListView(
+                  children: [
+                    Container(
+                      width: double.infinity,
+                      height: 120,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(20),
+                        color: Colors.white,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text('코엑스'), //title
+                          Text('문화,예술>컨벤션센터'), //category
+                          Text('서울특별시 강남구 영동대로 513'), //address
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
### 🚀 개요
리스트 뷰 내에 컨테이너 위젯 틀 완성

### 🔧 변경사항
- backgroundColor 설정 하고 위젯 안에 Column사용하여 title, category, roadAddress를 세로로 정렬
- 스크롤가능하도록 Scaffold Body 자녀위젯 내에 Listview 배치

### 실행 화면
<img src="https://github.com/user-attachments/assets/8257c67b-bfd1-486c-86f7-fcbfcba615ba" width="300" height="600"/>

### 💡issue : #3 